### PR TITLE
Change embed inlining so that it works with c++

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin/*
 node_modules
 pages
 runenv.sh
+.vscode/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,1 @@
-{
-    "haxe.displayConfigurations": [
-        ["build.hxml"]
-    ]
-}
+{}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,6 +1,20 @@
 {
     "version": "2.0.0",
-    "command": "haxe",
-    "args": ["build.hxml"],
-    "problemMatcher": "$haxe"
+    "tasks": [
+        {
+            "type": "hxml",
+            "file": "build.hxml",
+            "problemMatcher": [
+                "$haxe-absolute",
+                "$haxe",
+                "$haxe-error",
+                "$haxe-trace"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "label": "haxe: build.hxml"
+        }
+    ]
 }

--- a/build.hxml
+++ b/build.hxml
@@ -28,11 +28,16 @@
 # com.raidandfade.haxicord.endpoints.Endpoints
 # -neko bin/Haxicord-neko/Haxicord.n
 
--cp src
+# -cp src
 # -lib nme
 # -lib hxnodejs
--main com.raidandfade.haxicord.test.Test
--debug
+# -main com.raidandfade.haxicord.test.Test
+# -debug
 # --js test/bin/Haxicord-js/Haxicord.js
 --cpp test/bin/Haxicord-cpp
 # --neko test/bin/Haxicord-neko/Haxicord.n
+
+-cp src
+-main com.raidandfade.haxicord.test.Test
+--debug
+# -hl test/bin/Haxicord-hlc/haxicord.c

--- a/hxformat.json
+++ b/hxformat.json
@@ -1,0 +1,5 @@
+{
+    "indentation": {
+        "character": "    "
+    }
+}

--- a/src/com/raidandfade/haxicord/endpoints/Endpoints.hx
+++ b/src/com/raidandfade/haxicord/endpoints/Endpoints.hx
@@ -292,6 +292,13 @@ class Endpoints{
         @param cb - Return the message sent, or an error
      */
     public function sendMessage(channel_id:String, message:Typedefs.MessageCreate, cb:Message->ErrorReport->Void = null) {
+        if(message.embed != null && message.embed.fields != null){
+            for(field in message.embed.fields){
+                if(field._inline != null && field._inline == true){
+                    Reflect.setField(field,"inline",true);
+                }
+            }
+        }
         //Requires send_messages
         var endpoint = new EndpointPath("/channels/{0}/messages", [channel_id]);
         callEndpoint("POST", endpoint, function(m, e) {

--- a/src/com/raidandfade/haxicord/types/structs/Embed.hx
+++ b/src/com/raidandfade/haxicord/types/structs/Embed.hx
@@ -1,6 +1,5 @@
 package com.raidandfade.haxicord.types.structs;
 
-
 // @serverside is for when you decide to at some point have an embed creator. fun times.
 
 typedef Embed = {
@@ -58,15 +57,8 @@ typedef EmbedAuthor = {
     @:optional @serverSide var proxy_icon_url:String; // http(s) and attachments.
 }
 
-@:structInit
-class EmbedField {
+typedef EmbedField = {
     @:optional var name:String;
     @:optional var value:String;
-    @:optional @:native("inline") var _inline:Bool;
-
-    public function new(name:String, value:String, _inline:Bool) {
-        this.name = name;
-        this.value = value;
-        this._inline = _inline;
-    }
+    @:optional var _inline:Bool;
 }

--- a/src/com/raidandfade/haxicord/websocket/WebSocketConnection.hx
+++ b/src/com/raidandfade/haxicord/websocket/WebSocketConnection.hx
@@ -138,11 +138,10 @@ class WebSocketConnection {
         ws.onerror = onError;
         ws.onclose = _onClose;
 #if sys
-        while (true) {
+        while (ws.readyState != Closed) {
             ws.process();
             Sys.sleep(0.1);
         }
-        trace("Escaped while, somehow.");
 #end
 #end
     }


### PR DESCRIPTION
The only fix I could think of was reflection in `endpoints.sendMessage`

Also adds a hxformat.json file so that the spaces don't get changed into tabs when one uses the formatter.
Also fixes the tasks.json file.